### PR TITLE
Fix casing for resolution of node modules

### DIFF
--- a/src/setup/web/src/index.html
+++ b/src/setup/web/src/index.html
@@ -72,7 +72,7 @@
         };
 
         for (var i = 0; i < dependencies.length; i += 1) {
-            config.paths[dependencies[i].toLowerCase() + "/lib"] = "../node_modules/" + dependencies[i] + "/src";
+            config.paths[dependencies[i].toLowerCase() + "/lib"] = "../node_modules/" + dependencies[i].toLowerCase() + "/src";
         }
 
         requirejs.config(config);


### PR DESCRIPTION
Node module folder names seem to be always lowercase.