### PR TITLE
Gulp scripts in generated package.json

### DIFF
--- a/src/tasks/setup/package.ts
+++ b/src/tasks/setup/package.ts
@@ -12,7 +12,7 @@ export default function taskClean(settings: IGulpSettings): any {
 
     let dependencies: any;
     const devDependencies: any = {
-        "gulp": "3.9.X",
+        "gulp": `${settings.shenanigans.dependencies.gulp}`,
         "gulp-shenanigans": `^${settings.shenanigans.version}`
     };
 

--- a/src/tasks/setup/package.ts
+++ b/src/tasks/setup/package.ts
@@ -68,6 +68,11 @@ export default function taskClean(settings: IGulpSettings): any {
 
     packageInfo.devDependencies = devDependencies;
 
+    packageInfo.scripts = {
+        "gulp": "gulp",
+        "test": "gulp test"
+    };
+
     return file("package.json", JSON.stringify(packageInfo), { src: true })
         .pipe(prettify({
             indent_level: 2,

--- a/src/tasks/setup/package.ts
+++ b/src/tasks/setup/package.ts
@@ -12,6 +12,7 @@ export default function taskClean(settings: IGulpSettings): any {
 
     let dependencies: any;
     const devDependencies: any = {
+        "gulp": "3.9.X",
         "gulp-shenanigans": `^${settings.shenanigans.version}`
     };
 


### PR DESCRIPTION
Fixes #44. Also adds gulp as a dev dependency based on the version in this package (couldn't think of a better way to get an appropriate version of gulp to use)